### PR TITLE
Feature: vCard / VCF Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,10 @@
 ![Demo GIF](demo-chrome_extension.gif "Demo Gif")
 
 ## Usage / Installation Options:
-There are a few different options for how to use this:
+There are (or *were*) a few different options for how to use this:
  - **Fast and simple**: Chrome Extension - [Get it here](https://chrome.google.com/webstore/detail/jcaldklkmnjfpjaboilcejindjejbklh/)
      - Feel free to install, use, and then immediately uninstall if you just need a single export
      - No data is collected
- - **Fast, but manual**: Using browser dev console
-     - Step 1: Copy the code from [`main.js`](https://github.com/joshuatz/linkedin-to-jsonresume/blob/master/src/main.js) into your clipboard
-     - Step 2: Navigate to a LinkedIn profile page, then paste the code into your console and run it
-     - Step 3: Copy and run the following code:
-        ```javascript
-        (new LinkedinToResumeJson(false,false)).parseAndShowOutput();
-        ```
  - [***Deprecated***] (at least for now): Bookmarklet
      - This was originally how this tool worked, but had to be retired as a valid method when LinkedIn added a stricter CSP that prevented it from working
      - Code to generate the bookmarklet is still in this repo if LI ever loosens the CSP
@@ -34,6 +27,12 @@ I've implemented support (starting with `v1.0.0`) for multilingual profile expor
 The dropdown should automatically get populated with the languages that the profile you are currently viewing supports, in addition to your own preferred viewing language in the #1 spot. You should be able to switch between languages in the dropdown and click the export button to get a JSON Resume export with your selected language.
 
 > Note: LinkedIn offers language choices through [a `Locale` string](https://developer.linkedin.com/docs/ref/v2/object-types#LocaleString), which is a combination of `country` (ISO-3166) and `language` (ISO-639). I do not make decisions as to what languages are supported.
+
+### Export Options
+There are several main buttons in the browser extension, with different effects. You can hover over each button to see the alt text describing what they do, or read below:
+ - *LinkedIn Profile to JSON*: Converts the profile to the JSON Resume format, and then displays it in a popup modal for easy copying and pasting
+ - *Download JSON Resume Export*: Same as above, but prompts you to download the result as an actual `.json` file.
+ - *Download vCard File*: Export and download the profile as a Virtual Contact File (`.vcf`) (aka *vCard*)
 
 ### Chrome Side-loading Instructions
 Instead of installing from the Chrome Webstore, you might might want to "side-load" a ZIP build for either local development, or to try out a new release that has not yet made it through the Chrome review process. Here are the instructions for doing so:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ When in doubt, refresh the profile page before using this tool.
 ## Updates:
 Date | Release | Notes
 --- | --- | ---
+6/5/2020 | 1.1.0 | New feature: [vCard](https://en.wikipedia.org/wiki/VCard) export, which you can import into Outlook / Google Contacts / etc.
 5/31/2020 | 1.0.0 | Brought output up to par with "spec", integrated schemas as TS, added support for multilingual profiles, overhauled JSDoc types.<br><br>Definitely a *breaking* change, since the output has changed to mirror schema more closely (biggest change is `website` in several spots has become `url`)
 5/9/2020 | 0.0.9 | Fixed "references", added certificates (behind setting), and formatting tweaks
 4/4/2020 | 0.0.8 | Added version string display to popup

--- a/browser-ext/popup.html
+++ b/browser-ext/popup.html
@@ -11,7 +11,8 @@
 
 <body>
     <div class="fullCenter">
-        <div id="liToJsonButton" class="mainExportButton disabled toggle">LinkedIn Profile to JSON</div>
+        <button id="liToJsonButton" class="mainButton disabled toggle" title="Export profile to JSON Resume">LinkedIn Profile to JSON</button>
+        <button id="vcardExportButton" class="mainButton disabled toggle" title="Download vCard File">📟</button>
     </div>
     <div class="fullCenter">
         <div class="langSelectWrapper">

--- a/browser-ext/popup.html
+++ b/browser-ext/popup.html
@@ -12,7 +12,8 @@
 <body>
     <div class="fullCenter">
         <button id="liToJsonButton" class="mainButton disabled toggle" title="Export profile to JSON Resume">LinkedIn Profile to JSON</button>
-        <button id="vcardExportButton" class="mainButton disabled toggle" title="Download vCard File">📟</button>
+        <button id="liToJsonDownloadButton" class="mainButton emojiButton disabled toggle" title="Download JSON Resume Export">💾</button>
+        <button id="vcardExportButton" class="mainButton emojiButton disabled toggle" title="Download vCard File">📠</button>
     </div>
     <div class="fullCenter">
         <div class="langSelectWrapper">
@@ -25,8 +26,8 @@
         </div>
     </div>
     <div class="fullCenter bottomButtonsWrapper">
-        <a class="bottomButton" href="https://github.com/joshuatz/linkedin-to-jsonresume" target="_blank"><div class="">Info</div></a>
-        <a class="bottomButton" href="https://github.com/joshuatz/linkedin-to-jsonresume/issues/new" target="_blank"><div class="">Report Issue</div></a>
+        <a class="bottomButton" href="https://github.com/joshuatz/linkedin-to-jsonresume" target="_blank" title="Info about the extension. Takes you to Github page."><div>Info</div></a>
+        <a class="bottomButton" href="https://github.com/joshuatz/linkedin-to-jsonresume/issues/new" target="_blank" title="Report an issue or request a feature."><div>Report Issue</div></a>
     </div>
     <div class="fullCenter">
         <span>Version: </span><span id="versionDisplay">{version_string}</span>

--- a/browser-ext/popup.js
+++ b/browser-ext/popup.js
@@ -58,6 +58,12 @@ const loadLangs = (langs) => {
     toggleEnabled(langs.length > 0);
 };
 
+const exportVCard = () => {
+    chrome.tabs.executeScript({
+        code: `liToJrInstance.generateVCard()`
+    });
+};
+
 /**
  * Set the desired export lang on the exporter instance
  * - Use `null` to unset
@@ -131,4 +137,8 @@ document.getElementById('liToJsonButton').addEventListener('click', () => {
 document.getElementById('langSelect').addEventListener('change', (evt) => {
     const updatedLang = /** @type {HTMLSelectElement} */ (evt.target).value;
     setLang(updatedLang);
+});
+
+document.getElementById('vcardExportButton').addEventListener('click', () => {
+    exportVCard();
 });

--- a/browser-ext/popup.js
+++ b/browser-ext/popup.js
@@ -116,22 +116,21 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 document.getElementById('liToJsonButton').addEventListener('click', () => {
     chrome.tabs.executeScript(
         {
-            file: 'main.js'
+            code: `${runAndShowCode}`
         },
         () => {
-            chrome.tabs.executeScript(
-                {
-                    code: `${runAndShowCode}`
-                },
-                () => {
-                    setTimeout(() => {
-                        // Close popup
-                        window.close();
-                    }, 700);
-                }
-            );
+            setTimeout(() => {
+                // Close popup
+                window.close();
+            }, 700);
         }
     );
+});
+
+document.getElementById('liToJsonDownloadButton').addEventListener('click', () => {
+    chrome.tabs.executeScript({
+        code: `liToJrInstance.parseAndDownload();`
+    });
 });
 
 document.getElementById('langSelect').addEventListener('change', (evt) => {

--- a/browser-ext/styles.css
+++ b/browser-ext/styles.css
@@ -1,8 +1,8 @@
 body {
-    min-width: 350px;
+    min-width: 400px;
     min-height: 100px;
 }
-.mainExportButton {
+.mainButton {
     font-size: 21px;
     -moz-box-shadow:inset 0px 1px 0px 0px #97c4fe;
     -webkit-box-shadow:inset 0px 1px 0px 0px #97c4fe;
@@ -28,7 +28,7 @@ body {
     text-decoration:none;
     text-shadow:0px 1px 0px #1570cd;
 }
-.mainExportButton:hover {
+.mainButton:hover {
     background:-webkit-gradient(linear, left top, left bottom, color-stop(0.05, #1e62d0), color-stop(1, #3d94f6));
     background:-moz-linear-gradient(top, #1e62d0 5%, #3d94f6 100%);
     background:-webkit-linear-gradient(top, #1e62d0 5%, #3d94f6 100%);
@@ -38,13 +38,16 @@ body {
     filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#1e62d0', endColorstr='#3d94f6',GradientType=0);
     background-color:#1e62d0;
 }
-.mainExportButton:active {
+.mainButton:active {
     position:relative;
     top:1px;
 }
-.mainExportButton.disabled {
+.mainButton.disabled {
     background: grey;
     border: black;
+}
+#vcardExportButton {
+    padding: 2px 6px 6px 6px;
 }
 .disabled {
     cursor: not-allowed;

--- a/browser-ext/styles.css
+++ b/browser-ext/styles.css
@@ -46,7 +46,7 @@ body {
     background: grey;
     border: black;
 }
-#vcardExportButton {
+.emojiButton {
     padding: 2px 6px 6px 6px;
 }
 .disabled {

--- a/global.d.ts
+++ b/global.d.ts
@@ -36,6 +36,26 @@ interface LiSupportedLocale {
     $type: string;
 }
 
+interface LiDate {
+    month?: number;
+    day?: number;
+    year?: number;
+}
+
+interface LiPhoneNum {
+    number: string;
+    type: string;
+}
+
+interface LiWebsite {
+    url: string;
+    type: {
+        $type: string;
+        category: string;
+    }
+    $type: string;
+}
+
 type TocValModifier = (tocVal: string | string[]) => string | string[];
 
 interface InternalDb {
@@ -47,4 +67,22 @@ interface InternalDb {
     // Methods
     getElementKeys: () => string[];
     getValuesByKey: (key: LiUrn, optTocValModifier?: TocValModifier) => LiEntity[]; 
+}
+
+interface LiProfileContactInfoResponse extends LiResponse {
+    data: LiResponse['data'] & Partial<LiEntity> & {
+        $type: 'com.linkedin.voyager.identity.profile.ProfileContactInfo';
+        address: string;
+        birthDateOn: LiDate;
+        birthdayVisibilitySetting: any;
+        connectedAt: null | number;
+        emailAddress: null | string;
+        ims: any;
+        interests: any;
+        phoneNumbers: null | LiPhoneNum[];
+        primaryTwitterHandle: null | string;
+        twitterHandles: any[];
+        weChatContactInfo: any;
+        websites: null | LiWebsite[];
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "linkedin-to-json-resume-exporter",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1040,6 +1040,11 @@
                 "lodash": "^4.17.13",
                 "to-fast-properties": "^2.0.0"
             }
+        },
+        "@dan/vcards": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@dan/vcards/-/vcards-2.10.0.tgz",
+            "integrity": "sha512-wyi+wTyDxwxvQ98FwJbiF98Z5PbZog8u7JhWZ9N86UNa41KC0tAHbRnKtj0Nsn8jHc4lRUZU9K2sEpd9kix5aw=="
         },
         "@types/chrome": {
             "version": "0.0.103",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "linkedin-to-json-resume-exporter",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Browser tool to grab details from your open LinkedIn profile page and export to JSON Resume Schema",
     "main": "src/main.js",
     "scripts": {
@@ -53,5 +53,8 @@
                 }
             ]
         ]
+    },
+    "dependencies": {
+        "@dan/vcards": "^2.10.0"
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -950,6 +950,14 @@ window.LinkedinToResumeJson = (() => {
         });
     };
 
+    LinkedinToResumeJson.prototype.parseAndDownload = async function parseAndDownload() {
+        await this.tryParse();
+        const fileName = `${_outputJson.basics.name.replace(/\s/g, '_')}.resume.json`;
+        const fileContents = JSON.stringify(_outputJson, null, 2);
+        this.debugConsole.log(fileContents);
+        promptDownload(fileContents, fileName, 'application/json');
+    };
+
     LinkedinToResumeJson.prototype.parseAndShowOutput = async function parseAndShowOutput() {
         await this.tryParse();
         const parsedExport = {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,5 +1,6 @@
 const path = require('path');
 
+/** @type {import('webpack').Configuration} */
 module.exports = {
     mode: 'development',
     entry: './src/main.js',
@@ -7,6 +8,7 @@ module.exports = {
         filename: 'main.js',
         path: path.resolve(__dirname, 'build')
     },
+    target: 'web',
     module: {
         rules: [
             {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,5 +1,6 @@
 const path = require('path');
 
+/** @type {import('webpack').Configuration} */
 module.exports = {
     mode: 'production',
     entry: './src/main.js',
@@ -7,6 +8,7 @@ module.exports = {
         filename: 'main.js',
         path: path.resolve(__dirname, 'build')
     },
+    target: 'web',
     module: {
         rules: [
             {


### PR DESCRIPTION
This will add a (requested) feature to the extension; the ability to generate and export a [vCard / `.vcf` (Virtual Contact File)](https://en.wikipedia.org/wiki/VCard) from a given profile. These files can be imported into most address books, email programs, CRMs, etc.

I'm also reusing the download prompt code to implement a feature I should have added from the start, which is the ability to directly download the JSON Resume export, instead of just showing it in the modal to copy and paste. That ability is now baked into this feature PR as well.