### PR TITLE
Bugfix: Exporting your own multi-lingual profile, overriding defaultLocale

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,8 @@
     "browser": true
   },
   "rules": {
+    "no-self-assign": "off",
+    "no-param-reassign": "off",
     "no-underscore-dangle": "off",
     "no-plusplus": "off",
     "no-useless-escape": "off",

--- a/LinkedIn-Notes.md
+++ b/LinkedIn-Notes.md
@@ -5,7 +5,9 @@ Back to main README: [click here](./README.md)
  - V2 Docs:
      - https://docs.microsoft.com/en-us/linkedin/
      - https://developer.linkedin.com/docs/guide/v2
- - Another project that uses the unofficial Voyager API: [tomquirk/linkedin-api](https://github.com/tomquirk/linkedin-api)
+ - Other projects that use the unofficial Voyager API:
+     - [tomquirk/linkedin-api](https://github.com/tomquirk/linkedin-api)
+     - [eilonmore/linkedin-private-api](https://github.com/eilonmore/linkedin-private-api)
  - LinkedIn DataHub (this powers a lot of the backend)
      - [Blog Post](https://engineering.linkedin.com/blog/2019/data-hub)
      - [Github Repo](https://github.com/linkedin/datahub)
@@ -75,6 +77,33 @@ Here are some quick notes on Voyager responses and how data is grouped / nested:
      - This can also make paging a little messy.
  - LI has limits on certain endpoints, and the amount of nested elements it will return
      - See [PR #23](https://github.com/joshuatz/linkedin-to-jsonresume/pull/23) for an example of how this was implemented
+
+### Voyager - Misc Notes
+ - Make sure you always include the `Host` header if making requests outside a web browser (browsers will automatically include this for you)
+     - Value should be: `www.linkedin.com`
+     - If you forget it, you will get 400 error (`invalid hostname`)
+ - For inline data, `<code></code>` with request payload usually ***follows*** `<img><code></code>` with *response* payload
+ - It appears as though whatever language the profile was ***first*** created with sticks as the "principal language", regardless if user changes language settings (more on this below).
+     - You can find this under the main profile object, where you would find `supportedLocales` - the default / initial locale is under - `defaultLocale`
+
+### Voyager - Multilingual and Locales Support
+> LI seems to be making changes related to this; this section might not be 100% up-to-date.
+
+There are some really strange quirks around multi-locale profiles. When a multi-locale user is logged in and requesting *their own* profile, LI will *refuse* to let the `x-li-lang` header override the `defaultLocale` as specified by the profile (see [issue #35](https://github.com/joshuatz/linkedin-to-jsonresume/issues/35)). However, if *someone else* exports their profile, the same exact endpoints will respect the header and will return the correct data for the requested locale (assuming creator made a version of their profile with the requested locale).
+
+Even stranger, this quirk only seems to apply to *certain* endpoints; e.g. `/me` respects the requested language, but `/profileView` does not (and *always* returns data corresponding with `defaultLocale`) 🙃
+
+Furthermore, the `/dash` subset of endpoints does not ever (AFAIK) change the main key-value pairs based on `x-li-lang`; instead, it nests multi-locale data under `multiLocale` prefixed keys. For example:
+
+```json
+{
+    "firstName": "Алексе́й",
+    "multiLocaleFirstName": {
+        "ru_RU": "Алексе́й",
+        "en_US": "Alexey"
+    }
+}
+```
 
 ## LinkedIn TS Types
 I've put some basics LI types in my `global.d.ts`. Eventually, it would be nice to re-write the core of this project as TS, as opposed to the current VSCode-powered typed JS approached.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # LinkedIn Profile to JSON Resume Browser Tool ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/joshuatz/linkedin-to-jsonresume)
 
+> An extremely easy-to-use browser extension for exporting your full LinkedIn Profile to a JSON Resume file or string.
+
 ## Chrome Extension 📦 - [Webstore Link](https://chrome.google.com/webstore/detail/json-resume-exporter/caobgmmcpklomkcckaenhjlokpmfbdec)
 
-## My LinkedIn Profile 👨‍💼 - [https://www.linkedin.com/in/joshuatzucker/](https://www.linkedin.com/in/joshuatzucker/)
+## My LinkedIn Profile 👨‍💼 - [linkedin.com/in/joshuatzucker/](https://www.linkedin.com/in/joshuatzucker/)
 
 ![Demo GIF](demo-chrome_extension.gif "Demo Gif")
 

--- a/browser-ext/popup.js
+++ b/browser-ext/popup.js
@@ -12,6 +12,8 @@ const STORAGE_KEYS = {
 const SPEC_SELECT = /** @type {HTMLSelectElement} */ (document.getElementById('specSelect'));
 /** @type {SchemaVersion[]} */
 const SPEC_OPTIONS = ['beta', 'stable', 'latest'];
+/** @type {HTMLSelectElement} */
+const LANG_SELECT = document.querySelector('.langSelect');
 
 /**
  * Generate injectable code for capturing a value from the contentScript scope and passing back via message
@@ -42,12 +44,19 @@ const getLangStringsCode = `(async () => {
 `;
 
 /**
+ * Get the currently selected lang locale in the selector
+ */
+const getSelectedLang = () => {
+    return LANG_SELECT.value;
+};
+
+/**
  * Get JS string that can be eval'ed to get the program to run and show output
  * Note: Be careful of strings versus vars, escaping, etc.
  * @param {SchemaVersion} version
  */
 const getRunAndShowCode = (version) => {
-    return `liToJrInstance.parseAndShowOutput('${version}');`;
+    return `liToJrInstance.preferLocale = '${getSelectedLang()}';liToJrInstance.parseAndShowOutput('${version}');`;
 };
 
 /**
@@ -66,14 +75,12 @@ const toggleEnabled = (isEnabled) => {
  * @param {string[]} langs
  */
 const loadLangs = (langs) => {
-    /** @type {HTMLSelectElement} */
-    const selectElem = document.querySelector('.langSelect');
-    selectElem.innerHTML = '';
+    LANG_SELECT.innerHTML = '';
     langs.forEach((lang) => {
         const option = document.createElement('option');
         option.value = lang;
         option.innerText = lang;
-        selectElem.appendChild(option);
+        LANG_SELECT.appendChild(option);
     });
     toggleEnabled(langs.length > 0);
 };
@@ -171,13 +178,12 @@ document.getElementById('liToJsonButton').addEventListener('click', async () => 
 
 document.getElementById('liToJsonDownloadButton').addEventListener('click', () => {
     chrome.tabs.executeScript({
-        code: `liToJrInstance.parseAndDownload();`
+        code: `liToJrInstance.preferLocale = '${getSelectedLang()}';liToJrInstance.parseAndDownload();`
     });
 });
 
-document.getElementById('langSelect').addEventListener('change', (evt) => {
-    const updatedLang = /** @type {HTMLSelectElement} */ (evt.target).value;
-    setLang(updatedLang);
+LANG_SELECT.addEventListener('change', () => {
+    setLang(getSelectedLang());
 });
 
 document.getElementById('vcardExportButton').addEventListener('click', () => {

--- a/global.d.ts
+++ b/global.d.ts
@@ -118,7 +118,8 @@ declare global {
 
     interface ParseProfileSchemaResultSummary {
         liResponse: LiResponse;
-        profileObj: LiResponse;
+        profileInfoObj?: LiEntity;
+        profileSrc: 'profileView' | 'dashFullProfileWithEntities';
         pageUrl: string;
         localeStr?: string;
         parseSuccess: boolean;

--- a/global.d.ts
+++ b/global.d.ts
@@ -37,6 +37,7 @@ declare global {
     interface LiEntity {
         $type: string;
         entityUrn: LiUrn;
+        objectUrn?: LiUrn;
         [key: string]: any;
         paging?: LiPaging;
     }
@@ -82,9 +83,9 @@ declare global {
         // Methods
         getElementKeys: () => string[];
         getElements: () => Array<LiEntity & {key: LIUrn}>;
-        getValueByKey: (key: string) => LiEntity;
-        getValuesByKey: (key: LiUrn, optTocValModifier?: TocValModifier) => LiEntity[];
-        getElementsByType: (typeStr: string) => LiEntity[];
+        getValueByKey: (key: string | string[]) => LiEntity;
+        getValuesByKey: (key: LiUrn | LiUrn[], optTocValModifier?: TocValModifier) => LiEntity[];
+        getElementsByType: (typeStr: string | string []) => LiEntity[];
         getElementByUrn: (urn: string) => LiEntity | undefined;
         /**
          * Get multiple elements by URNs
@@ -116,6 +117,7 @@ declare global {
     type CaptureResult = 'success' | 'fail' | 'incomplete' | 'empty';
 
     interface ParseProfileSchemaResultSummary {
+        liResponse: LiResponse;
         profileObj: LiResponse;
         pageUrl: string;
         localeStr?: string;

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@
 
 const VCardsJS = require('@dan/vcards');
 const { resumeJsonTemplateLatest, resumeJsonTemplateStable, resumeJsonTemplateBetaPartial } = require('./templates');
+const { liSchemaKeys: _liSchemaKeys, liTypeMappings: _liTypeMappings } = require('./schema');
 
 // ==Bookmarklet==
 // @name linkedin-to-jsonresume-bookmarklet
@@ -126,92 +127,6 @@ window.LinkedinToResumeJson = (() => {
     let _supportedLocales = [];
     /** @type {string} */
     let _defaultLocale = `en_US`;
-    /**
-     * Lookup keys for the standard profileView object
-     */
-    const _liSchemaKeys = {
-        profile: '*profile',
-        certificates: '*certificationView',
-        education: '*educationView',
-        workPositions: '*positionView',
-        workPositionGroups: '*positionGroupView',
-        skills: '*skillView',
-        projects: '*projectView',
-        attachments: '*summaryTreasuryMedias',
-        volunteerWork: '*volunteerExperienceView',
-        awards: '*honorView',
-        publications: '*publicationView'
-    };
-    /**
-     * Try to maintain a mapping between generic section types, and LI's schema
-     *  - tocKeys are pointers that often point to a collection of URNs
-     *  - Try to put dash strings last, profileView first
-     *  - Most recipes are dash only
-     */
-    const _liTypeMappings = {
-        profile: {
-            // There is no tocKey for profile in dash FullProfileWithEntries,
-            // due to how entry-point is configured
-            tocKeys: ['*profile'],
-            types: [
-                // regular profileView
-                'com.linkedin.voyager.identity.profile.Profile',
-                // dash FullProfile
-                'com.linkedin.voyager.dash.identity.profile.Profile'
-            ],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileWithEntities']
-        },
-        certificates: {
-            tocKeys: ['*certificationView', '*profileCertifications'],
-            types: ['com.linkedin.voyager.dash.identity.profile.Certification'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileCertification']
-        },
-        education: {
-            tocKeys: ['*educationView', '*profileEducations'],
-            types: [
-                'com.linkedin.voyager.identity.profile.Education',
-                // Dash
-                'com.linkedin.voyager.dash.identity.profile.Education'
-            ],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileEducation']
-        },
-        // Individual work entries (not aggregate (workgroup) with date range)
-        workPositions: {
-            tocKeys: ['*positionView', '*profilePositionGroups'],
-            types: ['com.linkedin.voyager.identity.profile.Position', 'com.linkedin.voyager.dash.identity.profile.Position'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfilePosition']
-        },
-        skills: {
-            tocKeys: ['*skillView', '*profileSkills'],
-            types: ['com.linkedin.voyager.identity.profile.Skill', 'com.linkedin.voyager.dash.identity.profile.Skill'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileSkill']
-        },
-        projects: {
-            tocKeys: ['*projectView', '*profileProjects'],
-            types: ['com.linkedin.voyager.identity.profile.Project', 'com.linkedin.voyager.dash.identity.profile.Project'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileProject']
-        },
-        attachments: {
-            tocKeys: ['*summaryTreasuryMedias', '*profileTreasuryMediaPosition'],
-            types: ['com.linkedin.voyager.identity.profile.Certification', 'com.linkedin.voyager.dash.identity.profile.treasury.TreasuryMedia'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileTreasuryMedia']
-        },
-        volunteerWork: {
-            tocKeys: ['*volunteerExperienceView', '*profileVolunteerExperiences'],
-            types: ['com.linkedin.voyager.dash.identity.profile.VolunteerExperience'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileVolunteerExperience']
-        },
-        awards: {
-            tocKeys: ['*honorView', '*profileHonors'],
-            types: ['com.linkedin.voyager.identity.profile.Honor', 'com.linkedin.voyager.dash.identity.profile.Honor'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileHonor']
-        },
-        publications: {
-            tocKeys: ['*publicationView', '*profilePublications'],
-            types: ['com.linkedin.voyager.identity.profile.Publication', 'com.linkedin.voyager.dash.identity.profile.Publication'],
-            recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfilePublication']
-        }
-    };
     const _voyagerBase = 'https://www.linkedin.com/voyager/api';
     const _voyagerEndpoints = {
         following: '/identity/profiles/{profileId}/following',
@@ -1825,10 +1740,9 @@ window.LinkedinToResumeJson = (() => {
             // Get via miniProfile entity in full profile db
             const { liResponse, profileSrc, profileInfoObj } = await this.getParsedProfile();
             const profileDb = buildDbFromLiSchema(liResponse);
-            const fullProfile = profileDb.getValuesByKey(_liSchemaKeys.profile)[0];
             let pictureMeta;
             if (profileSrc === 'profileView') {
-                const miniProfile = profileDb.getElementByUrn(fullProfile['*miniProfile']);
+                const miniProfile = profileDb.getElementByUrn(profileInfoObj['*miniProfile']);
                 if (miniProfile && !!miniProfile.picture) {
                     pictureMeta = miniProfile.picture;
                 }
@@ -1844,22 +1758,22 @@ window.LinkedinToResumeJson = (() => {
     };
 
     LinkedinToResumeJson.prototype.generateVCard = async function generateVCard() {
-        const { liResponse } = await this.getParsedProfile();
+        const profileResSummary = await this.getParsedProfile();
         const contactInfoObj = await this.voyagerFetch(_voyagerEndpoints.contactInfo);
-        this.exportVCard(liResponse, contactInfoObj);
+        this.exportVCard(profileResSummary, contactInfoObj);
     };
 
     /**
-     * @param {LiResponse} profileResponse
+     * @param {ParseProfileSchemaResultSummary} profileResult
      * @param {LiResponse} contactInfoObj
      */
-    LinkedinToResumeJson.prototype.exportVCard = async function exportVCard(profileResponse, contactInfoObj) {
+    LinkedinToResumeJson.prototype.exportVCard = async function exportVCard(profileResult, contactInfoObj) {
         const vCard = VCardsJS();
-        const profileDb = buildDbFromLiSchema(profileResponse);
+        const profileDb = buildDbFromLiSchema(profileResult.liResponse);
         const contactDb = buildDbFromLiSchema(contactInfoObj);
         // Contact info is stored directly in response; no lookup
         const contactInfo = /** @type {LiProfileContactInfoResponse['data']} */ (contactDb.tableOfContents);
-        const profile = profileDb.getValuesByKey(_liSchemaKeys.profile)[0];
+        const profile = profileResult.profileInfoObj;
         vCard.formattedName = `${profile.firstName} ${profile.lastName}`;
         vCard.firstName = profile.firstName;
         vCard.lastName = profile.lastName;
@@ -1871,7 +1785,7 @@ window.LinkedinToResumeJson = (() => {
         vCard.email = contactInfo.emailAddress;
         if (contactInfo.twitterHandles.length) {
             // @ts-ignore
-            vCard.socialUrls['twitter'] = `https://twitter.com/${contactInfo.twitterHandles[0]}`;
+            vCard.socialUrls['twitter'] = `https://twitter.com/${contactInfo.twitterHandles[0].name}`;
         }
         if (contactInfo.phoneNumbers) {
             contactInfo.phoneNumbers.forEach((numberObj) => {
@@ -1902,7 +1816,7 @@ window.LinkedinToResumeJson = (() => {
             }
         }
         // Try to get currently employed organization
-        const positions = profileDb.getValuesByKey(_liSchemaKeys.workPositions);
+        const positions = profileDb.getElementsByType(_liTypeMappings.workPositions.types);
         if (positions.length) {
             vCard.organization = positions[0].companyName;
             vCard.title = positions[0].title;
@@ -1934,7 +1848,7 @@ window.LinkedinToResumeJson = (() => {
     };
 
     /**
-     *
+     * API fetching, with auto pagination
      * @param {string} fetchEndpoint
      * @param {Record<string, string | number>} [optHeaders]
      * @param {number} [start]
@@ -2082,7 +1996,6 @@ window.LinkedinToResumeJson = (() => {
                     method: 'GET',
                     mode: 'cors'
                 };
-                _this.debugConsole.log(`Fetching: ${endpoint}`, fetchOptions);
                 fetch(endpoint, fetchOptions).then((response) => {
                     if (response.status !== 200) {
                         const errStr = 'Error fetching internal API endpoint';

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,91 @@
+/**
+ * Lookup keys for the standard profileView object
+ */
+const liSchemaKeys = {
+    profile: '*profile',
+    certificates: '*certificationView',
+    education: '*educationView',
+    workPositions: '*positionView',
+    workPositionGroups: '*positionGroupView',
+    skills: '*skillView',
+    projects: '*projectView',
+    attachments: '*summaryTreasuryMedias',
+    volunteerWork: '*volunteerExperienceView',
+    awards: '*honorView',
+    publications: '*publicationView'
+};
+/**
+ * Try to maintain a mapping between generic section types, and LI's schema
+ *  - tocKeys are pointers that often point to a collection of URNs
+ *  - Try to put dash strings last, profileView first
+ *  - Most recipes are dash only
+ */
+const liTypeMappings = {
+    profile: {
+        // There is no tocKey for profile in dash FullProfileWithEntries,
+        // due to how entry-point is configured
+        tocKeys: ['*profile'],
+        types: [
+            // regular profileView
+            'com.linkedin.voyager.identity.profile.Profile',
+            // dash FullProfile
+            'com.linkedin.voyager.dash.identity.profile.Profile'
+        ],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileWithEntities']
+    },
+    certificates: {
+        tocKeys: ['*certificationView', '*profileCertifications'],
+        types: ['com.linkedin.voyager.dash.identity.profile.Certification'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileCertification']
+    },
+    education: {
+        tocKeys: ['*educationView', '*profileEducations'],
+        types: [
+            'com.linkedin.voyager.identity.profile.Education',
+            // Dash
+            'com.linkedin.voyager.dash.identity.profile.Education'
+        ],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileEducation']
+    },
+    // Individual work entries (not aggregate (workgroup) with date range)
+    workPositions: {
+        tocKeys: ['*positionView', '*profilePositionGroups'],
+        types: ['com.linkedin.voyager.identity.profile.Position', 'com.linkedin.voyager.dash.identity.profile.Position'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfilePosition']
+    },
+    skills: {
+        tocKeys: ['*skillView', '*profileSkills'],
+        types: ['com.linkedin.voyager.identity.profile.Skill', 'com.linkedin.voyager.dash.identity.profile.Skill'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileSkill']
+    },
+    projects: {
+        tocKeys: ['*projectView', '*profileProjects'],
+        types: ['com.linkedin.voyager.identity.profile.Project', 'com.linkedin.voyager.dash.identity.profile.Project'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileProject']
+    },
+    attachments: {
+        tocKeys: ['*summaryTreasuryMedias', '*profileTreasuryMediaPosition'],
+        types: ['com.linkedin.voyager.identity.profile.Certification', 'com.linkedin.voyager.dash.identity.profile.treasury.TreasuryMedia'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileTreasuryMedia']
+    },
+    volunteerWork: {
+        tocKeys: ['*volunteerExperienceView', '*profileVolunteerExperiences'],
+        types: ['com.linkedin.voyager.dash.identity.profile.VolunteerExperience'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileVolunteerExperience']
+    },
+    awards: {
+        tocKeys: ['*honorView', '*profileHonors'],
+        types: ['com.linkedin.voyager.identity.profile.Honor', 'com.linkedin.voyager.dash.identity.profile.Honor'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfileHonor']
+    },
+    publications: {
+        tocKeys: ['*publicationView', '*profilePublications'],
+        types: ['com.linkedin.voyager.identity.profile.Publication', 'com.linkedin.voyager.dash.identity.profile.Publication'],
+        recipes: ['com.linkedin.voyager.dash.deco.identity.profile.FullProfilePublication']
+    }
+};
+
+module.exports = {
+    liSchemaKeys,
+    liTypeMappings
+};


### PR DESCRIPTION
This fixes #35 

This ended up being a fairly complicated fix, because I could find no workable way to make the existing profile endpoint return data for a language other than the viewer's default locale (when looking at *your own* profile). So I had to reconfigure the various extractors and parsers to handle a new endpoint.

This endpoint also nests multi-lingual data, instead of just returning it separately, so I also had to write a utility to recurse through and grab the correct nested data based on the locale that is currently desired for export.

For full details, check the updated docs (which discusses the quirks of LI's multi-lingual system) and the commits on this PR. I'll push a new release after I do some extra cleanup (unrelated to this PR).